### PR TITLE
fix isChildDocument

### DIFF
--- a/app/src/main/java/me/alexbakker/webdav/provider/WebDavProvider.kt
+++ b/app/src/main/java/me/alexbakker/webdav/provider/WebDavProvider.kt
@@ -271,7 +271,7 @@ class WebDavProvider : DocumentsProvider() {
         // NOTE: This does not check whether the file actually exists
         val (account, filePath) = lookupDocumentId(documentId)
         val (parentAccount, parentPath) = lookupDocumentId(parentDocumentId)
-        val isChild = account.id == parentAccount.id && filePath.parent == parentPath
+        val isChild = account.id == parentAccount.id && filePath.startsWith(parentPath)
 
         Log.d(TAG, "isChildDocument(parentDocumentId=$parentDocumentId, documentId=$documentId): isChild=$isChild")
         return isChild


### PR DESCRIPTION
Fixes isChildDocument for grandparents, as the class documentation states: 

"Test if a document is descendant (child, **grandchild**, etc) from the given parent. For example, providers must implement this to support Intent.ACTION_OPEN_DOCUMENT_TREE. You should avoid making network requests to keep this request fast."

Signed-off-by: Jens Mueller <tschenser@gmx.de>