### PR TITLE
New option: Act as Local Storage, and Fix Verify Certificates.

### DIFF
--- a/app/schemas/me.alexbakker.webdav.data.AppDatabase/4.json
+++ b/app/schemas/me.alexbakker.webdav.data.AppDatabase/4.json
@@ -1,0 +1,169 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "f0be904d68b3a4378c9c305754c6c75c",
+    "entities": [
+      {
+        "tableName": "account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `url` TEXT, `protocol` TEXT NOT NULL DEFAULT 'AUTO', `verify_certs` INTEGER NOT NULL, `username` TEXT, `password` TEXT, `client_cert` TEXT, `max_cache_file_size` INTEGER NOT NULL, `act_as_local_storage` INTEGER NOT NULL DEFAULT false)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "protocol",
+            "columnName": "protocol",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'AUTO'"
+          },
+          {
+            "fieldPath": "verifyCerts",
+            "columnName": "verify_certs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "clientCert",
+            "columnName": "client_cert",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "maxCacheFileSize",
+            "columnName": "max_cache_file_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actAsLocalStorage",
+            "columnName": "act_as_local_storage",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "cache_entry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `account_id` INTEGER NOT NULL, `status` TEXT NOT NULL, `path` TEXT NOT NULL, `etag` TEXT, `content_length` INTEGER, `last_modified` INTEGER, FOREIGN KEY(`account_id`) REFERENCES `account`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "account_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "etag",
+            "columnName": "etag",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "contentLength",
+            "columnName": "content_length",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastModified",
+            "columnName": "last_modified",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cache_entry_account_id_path",
+            "unique": true,
+            "columnNames": [
+              "account_id",
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_cache_entry_account_id_path` ON `${TABLE_NAME}` (`account_id`, `path`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "account",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "account_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f0be904d68b3a4378c9c305754c6c75c')"
+    ]
+  }
+}

--- a/app/src/main/java/me/alexbakker/webdav/data/Account.kt
+++ b/app/src/main/java/me/alexbakker/webdav/data/Account.kt
@@ -44,7 +44,10 @@ data class Account(
     var clientCert: String? = null,
 
     @ColumnInfo(name = "max_cache_file_size")
-    var maxCacheFileSize: Long = 20
+    var maxCacheFileSize: Long = 20,
+
+    @ColumnInfo(name = "act_as_local_storage", defaultValue = "false")
+    var actAsLocalStorage: Boolean = false
 ) {
     private val authentication: Boolean
         get() {

--- a/app/src/main/java/me/alexbakker/webdav/data/AppDatabase.kt
+++ b/app/src/main/java/me/alexbakker/webdav/data/AppDatabase.kt
@@ -5,12 +5,13 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 
 @Database(
-    version = 3,
+    version = 4,
     exportSchema = true,
     entities = [Account::class, CacheEntry::class],
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
-        AutoMigration(from = 2, to = 3)
+        AutoMigration(from = 2, to = 3),
+        AutoMigration(from = 3, to = 4)
     ]
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/me/alexbakker/webdav/provider/WebDavProvider.kt
+++ b/app/src/main/java/me/alexbakker/webdav/provider/WebDavProvider.kt
@@ -407,7 +407,13 @@ class WebDavProvider : DocumentsProvider() {
         cursor.newRow().apply {
             add(Root.COLUMN_ROOT_ID, account.id)
             add(Root.COLUMN_SUMMARY, account.name)
-            add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE or Root.FLAG_SUPPORTS_IS_CHILD)
+            // Some Android apps only support opening files from DocumentsProviders that claim
+            // to offer content that's local to the device (i.e. no network requests are made)
+            var flags = Root.FLAG_SUPPORTS_CREATE or Root.FLAG_SUPPORTS_IS_CHILD
+            if (account.actAsLocalStorage){
+                flags = flags or Root.FLAG_LOCAL_ONLY
+            }
+            add(Root.COLUMN_FLAGS, flags)
             add(Root.COLUMN_TITLE, "WebDAV")
             add(Root.COLUMN_DOCUMENT_ID, buildDocumentId(account, account.rootPath))
             add(Root.COLUMN_MIME_TYPES, null)

--- a/app/src/main/res/layout/fragment_account.xml
+++ b/app/src/main/res/layout/fragment_account.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout
+<layout xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <data>
@@ -18,21 +18,24 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_form"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:paddingHorizontal="17.5dp">
+
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:id="@+id/text_layout_name"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/name"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent">
+
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/text_name"
                     android:layout_width="match_parent"
@@ -42,14 +45,15 @@
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:id="@+id/text_layout_url"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/url"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/text_layout_name">
+
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/text_url"
                     android:layout_width="match_parent"
@@ -62,23 +66,24 @@
                 android:id="@+id/switch_verify_certs"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:text="@string/verify_certs"
                 android:checked="@={account.verifyCerts}"
-                app:layout_constraintStart_toStartOf="parent"
+                android:text="@string/verify_certs"
+                app:layout_constraintBottom_toTopOf="@+id/text_layout_username"
                 app:layout_constraintEnd_toStartOf="@+id/layout_dropdown_protocol"
                 app:layout_constraintHorizontal_chainStyle="spread"
-                app:layout_constraintTop_toBottomOf="@+id/text_layout_url"
-                app:layout_constraintBottom_toTopOf="@+id/text_layout_username"/>
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/text_layout_url" />
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
                 android:id="@+id/layout_dropdown_protocol"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:hint="@string/protocol"
-                app:layout_constraintTop_toBottomOf="@+id/text_layout_url"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/switch_verify_certs"
-                app:layout_constraintEnd_toEndOf="parent">
+                app:layout_constraintTop_toBottomOf="@+id/text_layout_url">
+
                 <AutoCompleteTextView
                     android:id="@+id/dropdown_protocol"
                     android:layout_width="match_parent"
@@ -88,14 +93,15 @@
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:id="@+id/text_layout_username"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/username"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/layout_dropdown_protocol">
+
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/text_username"
                     android:layout_width="match_parent"
@@ -105,20 +111,21 @@
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:id="@+id/text_layout_password"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/password"
-                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/text_layout_username">
+
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/text_password"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:singleLine="true"
                     android:inputType="textPassword"
+                    android:singleLine="true"
                     android:text="@={account.password}" />
             </com.google.android.material.textfield.TextInputLayout>
 
@@ -166,12 +173,25 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:stepSize="5"
+                android:value="@={account.maxCacheFileSize}"
                 android:valueFrom="5"
                 android:valueTo="100"
-                android:value="@={account.maxCacheFileSize}"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/label_cache_file_size" />
+                app:layout_constraintTop_toBottomOf="@+id/label_cache_file_size"
+                tools:ignore="SpeakableTextPresentCheck" />
+
+            <com.google.android.material.checkbox.MaterialCheckBox
+                android:id="@+id/checkbox_act_as_local_storage"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:checked="@={account.actAsLocalStorage}"
+                android:text="@string/act_as_local_storage"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_chainStyle="spread"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/slider_max_cache_file_size" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+
     </LinearLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="url">URL</string>
     <string name="protocol">Protocol</string>
     <string name="verify_certs">Verify certificates</string>
+    <string name="act_as_local_storage">Act as Local Storage</string>
     <string name="authentication">Authentication</string>
     <string name="username">Username</string>
     <string name="password">Password</string>


### PR DESCRIPTION
* Added a new option: Act as local storage

Some Android apps only expect local storage only! Such as:
(AetherSX2, DuckStation PPSSPP emulators! and many more).
Some others don't care and accept any provider: Dolphin emulator and MSX.emu.
To be able to use WebDAV Provider in such apps, then we have to fool
them somehow! Making them believe they are dealing with local storage.

Thanks to @wa2c the author of CIFS Document Provider for this :)

* Verify Certificates option is now functional!

The default behavior is when it is enabled! Before this change,
WebDAV Provider was always verifying certificates. Disabling it
was not doing anything. Now it can ignore certificate errors, such
as ones from self-signed certificates or ones you create your own using
openssl command.

This is very useful when trying to connect to servers you trust! such as
your own servers like NAS Server at home!

Trusting all certificates with okHttp, code is from (I modified it slightly):
https://stackoverflow.com/questions/25509296/trusting-all-certificates-with-okhttp